### PR TITLE
Use lighter Meeko package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
       - setup.cfg
       - setup.py
   pull_request:
-    branches: [ "main" ]
+    types: [opened, synchronize, reopened]
     paths:
       - moldrug/**
       - .github/workflows/tests.yml
@@ -23,6 +23,10 @@ on:
       - setup.cfg
       - setup.py
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+  
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest] #windows-latest (vina is not available for windows in conda-forge),m think about use bioconda autodock-vina
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest] #windows-latest (vina is not available for windows in conda-forge),m think about use bioconda autodock-vina
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Meeko dependency and Python=3.12. Now we use a [simplified version of Meeko](https://github.com/ale94mleon/Meeko).
 - The tests no longer rely on `/tmp`; they now create temporary files in the current directory instead. This approach was already used throughout the package, except in the tests. The change makes the behavior consistent and avoids issues that occurred on certain clusters when using `/tmp`.
 - Prevent race condition when creating `error` directory during parallel execution.
 

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move from `.rst` to `.md` on the documentation.
 - Update installation instructions.
+- Versioning: `Major.Minor.Patch` --> `Major.Minnor.Patch.postX` it helps to distinguish commits that are not yet included on the `Patch`.
 
 ### Fixed
 

--- a/docs/source/CHANGELOG.md
+++ b/docs/source/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Removed
+
+- Python 3.8 compatibility. The dependency `meeko @ git+https://github.com/ale94mleon/meeko.git@main` requires a higher Python version because building it requires `setuptools>=77.0.0`, which is not compatible with Python 3.8.
+
 ### Changed
 
 - Move from `.rst` to `.md` on the documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,9 @@ cluster = ["dask[distributed]", "dask-jobqueue"]
 default-version = "1+unknown"
 
 [tool.versioningit.format]
-distance = "{base_version}"
-dirty = "{base_version}"
-distance-dirty = "{base_version}"
+distance = "{base_version}.post{distance}"
+dirty = "{base_version}.post{distance}.dev0"
+distance-dirty = "{base_version}.post{distance}.dev0"
 
 [tool.versioningit.vcs]
 method = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,20 @@
 [build-system]
-requires=[
+requires = [
     "setuptools>=77.0.0",
-	"versioningit",
+    "versioningit",
 ]
 build-backend = "setuptools.build_meta"
 
-[project.urls]
-Hompage = "https://github.com/ale94mleon/moldrug"
-Documentation = "https://moldrug.readthedocs.io/en/latest/"
-Discussions = "https://github.com/ale94mleon/moldrug/discussions"
-Issues = "https://github.com/ale94mleon/moldrug/issues"
-Changelog = "https://github.com/ale94mleon/moldrug/blob/main/docs/source/CHANGELOG.md"
-
 [project]
+requires-python = ">= 3.9 , < 3.14"
 name = "moldrug"
 dynamic = ["version"]
 description = "moldrug is a python package for drug-oriented optimization on the chemical space."
 readme = "README.rst"
 license-files = ["LICENSE"]
 
-authors=[
-    {name="Alejandro Martínez León", email="ale94mleon@gmail.com"},
+authors = [
+    { name = "Alejandro Martínez León", email = "ale94mleon@gmail.com" }
 ]
 
 classifiers = [
@@ -28,7 +22,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,6 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
+
 keywords = [
     "science",
     "chemistry",
@@ -46,7 +40,6 @@ keywords = [
     "genetic algorithm",
 ]
 
-requires-python = ">= 3.8 , < 3.14"
 dependencies = [
     "crem",
     "tqdm",
@@ -60,11 +53,16 @@ dependencies = [
     "rdkit>=2022.3.5",
 ]
 
-
-
 [project.optional-dependencies]
 dev = ["requests", "pytest", "dask[distributed]", "dask-jobqueue"]
 cluster = ["dask[distributed]", "dask-jobqueue"]
+
+[project.urls]
+Homepage = "https://github.com/ale94mleon/moldrug"
+Documentation = "https://moldrug.readthedocs.io/en/latest/"
+Discussions = "https://github.com/ale94mleon/moldrug/discussions"
+Issues = "https://github.com/ale94mleon/moldrug/issues"
+Changelog = "https://github.com/ale94mleon/moldrug/blob/main/docs/source/CHANGELOG.md"
 
 [tool.versioningit]
 default-version = "1+unknown"
@@ -95,7 +93,6 @@ moldrug = [
     "data/*/*.smi",
     "data/*/*.pdb",
     "data/*/*.pdbqt",
-
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
     "genetic algorithm",
 ]
 
-requires-python = ">= 3.8 , < 3.12"
+requires-python = ">= 3.8"
 dependencies = [
     "crem",
     "tqdm",
@@ -52,10 +52,10 @@ dependencies = [
     "pandas",
     "pyyaml",
     "dill",
-    "meeko>=0.4.0,<0.6.0",
+    "meeko @ git+https://github.com/ale94mleon/meeko.git@main",
+    "scipy",  # a meeko dependency
     "six",
     "rdkit>=2022.3.5",
-    "scipy",  # a meeko dependency
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires=[
-	"setuptools>=61.0",
+    "setuptools>=77.0.0",
 	"versioningit",
 ]
 build-backend = "setuptools.build_meta"
@@ -17,6 +17,7 @@ name = "moldrug"
 dynamic = ["version"]
 description = "moldrug is a python package for drug-oriented optimization on the chemical space."
 readme = "README.rst"
+license-files = ["LICENSE"]
 
 authors=[
     {name="Alejandro Martínez León", email="ale94mleon@gmail.com"},
@@ -26,12 +27,13 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
@@ -44,7 +46,7 @@ keywords = [
     "genetic algorithm",
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.8 , < 3.14"
 dependencies = [
     "crem",
     "tqdm",
@@ -58,11 +60,10 @@ dependencies = [
     "rdkit>=2022.3.5",
 ]
 
-[project.license]
-file = "LICENSE"
+
 
 [project.optional-dependencies]
-dev = ["requests", "pytest"]
+dev = ["requests", "pytest", "dask[distributed]", "dask-jobqueue"]
 cluster = ["dask[distributed]", "dask-jobqueue"]
 
 [tool.versioningit]
@@ -89,8 +90,6 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 moldrug = [
-    "LICENSE",
-    "README.rst",
     "data/*/*.yml",
     "data/*/*.mol",
     "data/*/*.smi",


### PR DESCRIPTION
- Replace the standard Meeko package by a [simple fork](https://github.com/ale94mleon/Meeko) which is easy to maintain. Future versions may default back to the standard library.
- Versioning to use `post` information too.
-  Fix #8 
- Close #9 and #10.
- This PR drops Python 3.8 support and adds compatibility with Python 3.12 and 3.13.